### PR TITLE
Fix field-space and factorize fmt_record_field

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -541,6 +541,29 @@ and fmt_payload c ctx pld =
       in
       fmt "?@ " $ fmt_pattern c (sub_pat ~ctx pat) $ opt exp fmt_when
 
+and fmt_record_field c ?typ ?rhs ?(type_first = false) lid1 =
+  let fmt_type ?(parens = false) t =
+    str ": " $ fmt_core_type c t $ fmt_if parens ")"
+  in
+  let fmt_rhs ?(parens = false) r =
+    fmt "=@;<1 2>" $ fmt_if parens "(" $ cbox 0 r
+  in
+  let field_space =
+    match c.conf.field_space with `Loose -> str " " | `Tight -> noop
+  in
+  let fmt_type_rhs =
+    match (typ, rhs) with
+    | Some t, Some r ->
+        if type_first then field_space $ fmt_type t $ fmt "@ " $ fmt_rhs r
+        else field_space $ fmt_rhs ~parens:true r $ fmt_type ~parens:true t
+    | Some t, None -> field_space $ fmt_type t
+    | None, Some r -> field_space $ fmt_rhs r
+    | None, None -> noop
+  in
+  Cmts.fmt_before c lid1.loc
+  $ cbox 0
+      (fmt_longident_loc c lid1 $ Cmts.fmt_after c lid1.loc $ fmt_type_rhs)
+
 and fmt_core_type c ?(box = true) ?(in_type_declaration = false) ?pro
     ?(pro_space = true) ({ast= typ} as xtyp) =
   protect (Typ typ)
@@ -845,59 +868,32 @@ and fmt_pattern c ?pro ?parens ({ctx= ctx0; ast= pat} as xpat) =
   | Ppat_record (flds, closed_flag) ->
       let fmt_field (lid1, pat) =
         let {ppat_desc; ppat_loc; ppat_attributes} = pat in
-        let maybe_cmts = Option.value_map ~default:Fn.id ~f:(Cmts.fmt c) in
-        let fmt_field ?field_loc ?cnstr_loc ?ident_loc ?typ ?pat ~ctx c =
-          let fmt_type ?(parens = false) t =
-            str ": " $ fmt_core_type c (sub_typ ~ctx t) $ fmt_if parens ")"
-          in
-          let fmt_pat ?(parens = false) ~ctx p =
-            fmt "=@;<1 2>" $ fmt_if parens "("
-            $ cbox 0 (fmt_pattern c (sub_pat ~ctx p))
-          in
-          let field_space =
-            match c.conf.field_space with
-            | `Loose -> str " "
-            | `Tight -> noop
-          in
-          maybe_cmts field_loc @@ maybe_cmts cnstr_loc
-          @@ cbox 0
-               ( maybe_cmts ident_loc @@ fmt_longident_loc c lid1
-               $
-               match (typ, pat) with
-               | Some t, Some p -> (
-                 match Source.typed_pattern t p with
-                 | `Type_first ->
-                     field_space $ fmt_type t $ fmt "@ " $ fmt_pat ~ctx p
-                 | `Pat_first ->
-                     field_space
-                     $ fmt_pat ~ctx ~parens:true p
-                     $ fmt_type ~parens:true t )
-               | Some t, None -> field_space $ fmt_type t
-               | None, Some p -> field_space $ fmt_pat ~ctx p
-               | None, None -> noop )
-        in
+        let fmt_rhs ~ctx p = fmt_pattern c (sub_pat ~ctx p) in
         hvbox 0
-          ( Cmts.fmt c lid1.loc @@ Cmts.fmt c ppat_loc
+          ( Cmts.fmt c ppat_loc
           @@
           match ppat_desc with
           | Ppat_var {txt= txt'}
             when field_alias ~field:lid1.txt (Longident.parse txt')
                  && List.is_empty ppat_attributes ->
-              fmt_field c ~ctx ~field_loc:pat.ppat_loc
+              fmt_record_field c lid1
           | Ppat_constraint ({ppat_desc= Ppat_var {txt; _}; ppat_loc}, t)
             when field_alias ~field:lid1.txt (Longident.parse txt)
                  && List.is_empty ppat_attributes ->
-              fmt_field c ~ctx:(Pat pat) ~field_loc:pat.ppat_loc
-                ~cnstr_loc:ppat_loc ~typ:t
+              let typ = sub_typ ~ctx:(Pat pat) t in
+              Cmts.fmt c ppat_loc @@ fmt_record_field c ~typ lid1
           | Ppat_constraint ({ppat_desc= Ppat_unpack _; ppat_loc}, _) ->
-              fmt_field c ~ctx ~field_loc:pat.ppat_loc ~cnstr_loc:ppat_loc
-                ~pat
+              Cmts.fmt c ppat_loc
+              @@ fmt_record_field c ~rhs:(fmt_rhs ~ctx pat) lid1
           | Ppat_constraint (p, t) when List.is_empty ppat_attributes ->
-              fmt_field c ~ctx:(Pat pat) ~field_loc:pat.ppat_loc
-                ~cnstr_loc:p.ppat_loc ~typ:t ~pat:p
-          | _ ->
-              fmt_field c ~ctx ~field_loc:pat.ppat_loc ~cnstr_loc:ppat_loc
-                ~pat )
+              let typ = sub_typ ~ctx:(Pat pat) t
+              and rhs = fmt_rhs ~ctx:(Pat pat) p in
+              let type_first =
+                Poly.equal `Type_first (Source.typed_pattern t p)
+              in
+              Cmts.fmt c p.ppat_loc
+              @@ fmt_record_field c ~typ ~rhs ~type_first lid1
+          | _ -> fmt_record_field c ~rhs:(fmt_rhs ~ctx pat) lid1 )
       in
       hvbox 0
         (wrap_if parens "(" ")"
@@ -1943,55 +1939,28 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (compose_module (fmt_module_expr c (sub_mod ~ctx me)) ~f:fmt_mod)
   | Pexp_record (flds, default) ->
       let fmt_field (lid1, f) =
-        let leading_cmt = Cmts.fmt_before c lid1.loc in
-        let maybe_cmts = Option.value_map ~default:Fn.id ~f:(Cmts.fmt c) in
-        let fmt_field ?field_loc ?cnstr_loc ?ident_loc ?typ ?expr c =
-          let fmt_type ?(parens = false) t =
-            str ": " $ fmt_core_type c (sub_typ ~ctx t) $ fmt_if parens ")"
-          in
-          let fmt_expr ?(parens = false) e =
-            fmt "=@ " $ fmt_if parens "("
-            $ cbox 0 (fmt_expression c (sub_exp ~ctx e))
-          in
-          let field_space =
-            match c.conf.field_space with
-            | `Loose -> str " "
-            | `Tight -> noop
-          in
-          maybe_cmts field_loc @@ maybe_cmts cnstr_loc
-          @@ cbox 2
-               ( maybe_cmts ident_loc @@ fmt_longident_loc c lid1
-               $
-               match (typ, expr) with
-               | Some t, Some e -> (
-                 match Source.typed_expression t e with
-                 | `Type_first ->
-                     field_space $ fmt_type t $ fmt "@ " $ fmt_expr e
-                 | `Expr_first ->
-                     field_space $ fmt_expr ~parens:true e
-                     $ fmt_type ~parens:true t )
-               | Some t, None -> field_space $ fmt_type t
-               | None, Some e -> field_space $ fmt_expr e
-               | None, None -> noop )
-        in
+        let fmt_rhs e = fmt_expression c (sub_exp ~ctx e) in
         hvbox 0
-          ( leading_cmt
-          $
-          match f.pexp_desc with
+          ( match f.pexp_desc with
           | Pexp_ident {txt; loc}
             when field_alias ~field:lid1.txt txt
                  && List.is_empty f.pexp_attributes ->
-              fmt_field c ~ident_loc:loc
+              fmt_record_field c lid1
           | Pexp_constraint ({pexp_desc= Pexp_ident {txt; loc}; pexp_loc}, t)
             when field_alias ~field:lid1.txt txt
                  && List.is_empty f.pexp_attributes ->
-              fmt_field c ~field_loc:f.pexp_loc ~cnstr_loc:pexp_loc
-                ~ident_loc:loc ~typ:t
+              Cmts.fmt c f.pexp_loc @@ Cmts.fmt c pexp_loc
+              @@ fmt_record_field c lid1 ~typ:(sub_typ ~ctx t)
           | Pexp_constraint ({pexp_desc= Pexp_pack _}, _) ->
-              fmt_field c ~expr:f
+              fmt_record_field c ~rhs:(fmt_rhs f) lid1
           | Pexp_constraint (e, t) when List.is_empty f.pexp_attributes ->
-              fmt_field c ~field_loc:f.pexp_loc ~typ:t ~expr:e
-          | _ -> fmt_field c ~expr:f )
+              let type_first =
+                Poly.equal `Type_first (Source.typed_expression t e)
+              in
+              Cmts.fmt c f.pexp_loc
+              @@ fmt_record_field c ~typ:(sub_typ ~ctx t) ~rhs:(fmt_rhs e)
+                   ~type_first lid1
+          | _ -> fmt_record_field c ~rhs:(fmt_rhs f) lid1 )
       in
       hvbox 0
         ( wrap_record c.conf

--- a/test/passing/break_record.ml
+++ b/test/passing/break_record.ml
@@ -1,6 +1,6 @@
 let xxxxxxxxxxxxxxxxxxxxxx x =
   { xxxxxxxxxxxxxx
-  ; xxxxxxxxxxxxxxxxxx= x
+  ; xxxxxxxxxxxxxxxxxx = x
   ; xxxxxxxxxxxxx
   }
 ;;

--- a/test/passing/comments_in_record.ml
+++ b/test/passing/comments_in_record.ml
@@ -56,3 +56,21 @@ type t =
       ; packed: bool }
   | Opaque of {name: string}
 [@@deriving compare, equal, hash, sexp]
+
+type t = {
+  (* c *) c (* c' *) : (* d *) d (* d' *)
+}
+
+let _ = {
+  (* a *) a (* a' *) = (* b *) b (* b' *);
+  (* c *) c (* c' *) : (* d *) d (* d' *) = (* e *) e (* e' *);
+  (* f *) f (* f' *);
+  (* g *) g (* g' *) = (* j *) ( (* h *) h (* h' *) : (* i *) i (* i' *) ) (* j' *)
+}
+
+let {
+  (* a *) a (* a' *) = (* b *) b (* b' *);
+  (* c *) c (* c' *) : (* d *) d (* d' *) = (* e *) e (* e' *);
+  (* f *) f (* f' *);
+  (* g *) g (* g' *) = (* j *) ( (* h *) h (* h' *) : (* i *) i (* i' *) ) (* j' *)
+} = x

--- a/test/passing/comments_in_record.ml.ref
+++ b/test/passing/comments_in_record.ml.ref
@@ -56,3 +56,21 @@ type t =
       ; packed: bool }
   | Opaque of {name: string}
 [@@deriving compare, equal, hash, sexp]
+
+type t = {(* c *) c (* c' *): (* d *) d (* d' *)}
+
+let _ =
+  { (* a *) a (* a' *)= (* b *) b (* b' *)
+  ; (* c *) c (* c' *): (* d *) d (* d' *) = (* e *) e (* e' *)
+  ; (* f *) f (* f' *)
+  ; (* j *)
+    (* g *) g (* g' *)= ((* h *) h (* h' *): (* i *) i (* i' *))
+    (* j' *) }
+
+let { (* a *) a (* a' *)= (* b *) b (* b' *)
+    ; (* c *) c (* c' *): (* d *) d (* d' *) = (* e *) e (* e' *)
+    ; (* f *) f (* f' *)
+    ; (* j *)
+      (* g *) g (* g' *)= ((* h *) h (* h' *): (* i *) i (* i' *))
+      (* j' *) } =
+  x

--- a/test/passing/exp_record.ml
+++ b/test/passing/exp_record.ml
@@ -1,13 +1,13 @@
 let x = {a= 1; b= true}
 
-let x = {a: int= b}
+let x = {a: int = b}
 
-let x {a: int= b} = 2
+let x {a: int = b} = 2
 
 [@@@ocamlformat "space-around-collection-expressions"]
 
 let x = { a= 1; b= true }
 
-let x = { a: int= b }
+let x = { a: int = b }
 
-let x { a: int= b } = 2
+let x { a: int = b } = 2

--- a/test/passing/issue85.ml
+++ b/test/passing/issue85.ml
@@ -1,5 +1,5 @@
 let f (module X) = X.x
 
-let f = function `A {x: int= _} -> ()
+let f = function `A {x: int = _} -> ()
 
 let f (`A | `B) = ()

--- a/test/passing/js_source.ml.ref
+++ b/test/passing/js_source.ml.ref
@@ -662,7 +662,7 @@ end = struct
 
   type 'a tag += Int : int tag
 
-  let ik = { tag= Int; label= "int"; write= string_of_int; read= int_of_string }
+  let ik = { tag = Int; label = "int"; write = string_of_int; read = int_of_string }
   let () = Hashtbl.add readTbl "int" (K ik)
 
   let () =
@@ -687,7 +687,7 @@ end = struct
   module Define (D : Desc) = struct
     type 'a tag += C : D.t tag
 
-    let k = { tag= C; label= D.label; write= D.write; read= D.read }
+    let k = { tag = C; label = D.label; write = D.write; read = D.read }
     let () = Hashtbl.add readTbl D.label (K k)
 
     let () =
@@ -1131,16 +1131,16 @@ type my_record =
 let my_record =
   let fields =
     [ Field
-        { label= "a"
-        ; field_type= Int
-        ; get= (fun { a } -> a)
-        ; set= (fun (r, _) x -> r := Some x)
+        { label = "a"
+        ; field_type = Int
+        ; get = (fun { a } -> a)
+        ; set = (fun (r, _) x -> r := Some x)
         }
     ; Field
-        { label= "b"
-        ; field_type= List String
-        ; get= (fun { b } -> b)
-        ; set= (fun (_, r) x -> r := Some x)
+        { label = "b"
+        ; field_type = List String
+        ; get = (fun { b } -> b)
+        ; set = (fun (_, r) x -> r := Some x)
         }
     ]
   in
@@ -1150,7 +1150,7 @@ let my_record =
     | Some a, Some b -> { a; b }
     | _ -> failwith "Some fields are missing in record of type my_record"
   in
-  Record { path= "My_module.my_record"; fields; create_builder; of_builder }
+  Record { path = "My_module.my_record"; fields; create_builder; of_builder }
 ;;
 
 (* Extension to recursive types and polymorphic variants *)
@@ -1333,9 +1333,9 @@ let ty_abc =
   in
   (* Coherence of sum_inj and sum_cases is checked by the typing *)
   Sum
-    { sum_proj= proj
-    ; sum_inj= inj
-    ; sum_cases=
+    { sum_proj = proj
+    ; sum_inj = inj
+    ; sum_cases =
         [ "A", TCarg (Thd, Int)
         ; "B", TCarg (Ttl Thd, String)
         ; "C", TCnoarg (Ttl (Ttl Thd))
@@ -1357,12 +1357,12 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
   let tcons = Pair (Pop t, Var) in
   Rec
     (Sum
-       { sum_proj=
+       { sum_proj =
            (function
            | `Nil -> "Nil", None
            | `Cons p -> "Cons", Some (Tdyn (tcons, p)))
-       ; sum_cases= [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
-       ; sum_inj=
+       ; sum_cases = [ "Nil", TCnoarg Thd; "Cons", TCarg (Ttl Thd, tcons) ]
+       ; sum_inj =
            (fun (type c) ->
              (function
               | Thd, Noarg -> `Nil
@@ -3154,8 +3154,8 @@ type ('a, 'b) pair =
   }
 
 let check : type s. (s t, s) pair -> bool = function
-  | { fst= BoolLit; snd= false } -> false
-  | { fst= IntLit; snd= 6 } -> false
+  | { fst = BoolLit; snd = false } -> false
+  | { fst = IntLit; snd = 6 } -> false
 ;;
 
 module type S = sig
@@ -3447,7 +3447,7 @@ f
 type 'a s = { s : (module S with type t = 'a) }
 
 ;;
-{ s=
+{ s =
     (module struct
       type t = int
 
@@ -3455,15 +3455,15 @@ type 'a s = { s : (module S with type t = 'a) }
     end)
 }
 
-let f { s= (module M) } = M.x
+let f { s = (module M) } = M.x
 
 (* Error *)
-let f (type a) ({ s= (module M) } : a s) = M.x
+let f (type a) ({ s = (module M) } : a s) = M.x
 
 type s = { s : (module S with type t = int) }
 
-let f { s= (module M) } = M.x
-let f { s= (module M) } { s= (module N) } = M.x + N.x
+let f { s = (module M) } = M.x
+let f { s = (module M) } { s = (module N) } = M.x + N.x
 
 module type S = sig
   val x : int
@@ -4468,7 +4468,7 @@ type 'a foo =
   ; y : int
   }
 
-let r = { { x= 0; y= 0 } with x= 0 }
+let r = { { x = 0; y = 0 } with x = 0 }
 let r' : string foo = r
 
 external foo : int = "%ignore"
@@ -4635,20 +4635,20 @@ type t =
   }
 
 ;;
-{ x= 3; z= 2 }
+{ x = 3; z = 2 }
 ;;
-fun { x= 3; z= 2 } -> ()
+fun { x = 3; z = 2 } -> ()
 
 (* mixed labels *)
 
 ;;
-{ x= 3; contents= 2 }
+{ x = 3; contents = 2 }
 
 (* private types *)
 type u = private { mutable u : int }
 
 ;;
-{ u= 3 }
+{ u = 3 }
 ;;
 fun x -> x.u <- 3
 
@@ -4661,7 +4661,7 @@ module M = struct
 end
 
 let f { M.x; y } = x + y
-let r = { M.x= 1; y= 2 }
+let r = { M.x = 1; y = 2 }
 let z = f r
 
 (* messages *)
@@ -4677,11 +4677,11 @@ type foo =
 
 type bar = { x : int }
 
-let f (r : bar) : foo = { r with z= 3 }
+let f (r : bar) : foo = { r with z = 3 }
 
 type foo = { x : int }
 
-let r : foo = { ZZZ.x= 2 }
+let r : foo = { ZZZ.x = 2 }
 
 ;;
 (ZZZ.X : int option)
@@ -4871,7 +4871,7 @@ module type S = sig
     }
 end
 
-let f (module M : S with type t = int) = { M.a= 0 }
+let f (module M : S with type t = int) = { M.a = 0 }
 let flag = ref false
 
 module F (S : sig
@@ -8113,25 +8113,25 @@ let f (A r) = r
 let f (A r) = r.x
 
 (* ok *)
-let f x = A { x; y= x }
+let f x = A { x; y = x }
 
 (* ok *)
-let f (A r) = A { r with y= r.x + 1 }
+let f (A r) = A { r with y = r.x + 1 }
 
 (* ok *)
-let f () = A { a= 1 }
+let f () = A { a = 1 }
 
 (* customized error message *)
-let f () = A { x= 1; y= 3 }
+let f () = A { x = 1; y = 3 }
 
 (* ok *)
 
 type _ t = A : { x : 'a; y : 'b } -> 'a t
 
-let f (A { x; y }) = A { x; y= () }
+let f (A { x; y }) = A { x; y = () }
 
 (* ok *)
-let f (A ({ x; y } as r)) = A { x= r.x; y= r.y }
+let f (A ({ x; y } as r)) = A { x = r.x; y = r.y }
 
 (* ok *)
 
@@ -8220,7 +8220,7 @@ end
 type _ c = C : [ `A ] c
 type t = T : { x : [< `A ] c } -> t
 
-let f (T { x= C }) = ()
+let f (T { x = C }) = ()
 
 module M : sig
   type 'a t
@@ -8276,7 +8276,7 @@ end = struct
     ; b : unit
     }
 
-  let _ = { a= () }
+  let _ = { a = () }
 end
 
 type t =
@@ -9255,7 +9255,7 @@ end
 module F3 = struct
   open M
 
-  let r = { x= true; z= 'z' }
+  let r = { x = true; z = 'z' }
 end
 
 (* fail for missing label *)
@@ -9272,7 +9272,7 @@ module OK = struct
     ; z : char
     }
 
-  let r = { x= 3; y= true }
+  let r = { x = 3; y = true }
 end
 
 (* ok *)
@@ -9287,7 +9287,7 @@ module F4 = struct
 
   type bar = { x : int }
 
-  let b : bar = { x= 3; y= 4 }
+  let b : bar = { x = 3; y = 4 }
 end
 
 (* fail but don't warn *)
@@ -9306,7 +9306,7 @@ module N = struct
     }
 end
 
-let r = { M.x= 3; N.y= 4 }
+let r = { M.x = 3; N.y = 4 }
 
 (* error: different definitions *)
 
@@ -9320,7 +9320,7 @@ module NM = struct
   include M
 end
 
-let r = { MN.x= 3; NM.y= 4 }
+let r = { MN.x = 3; NM.y = 4 }
 
 (* error: type would change with order *)
 
@@ -9344,7 +9344,7 @@ module F5 = struct
 
   let f r =
     ignore (r : foo);
-    { r with x= 2; z= 3 }
+    { r with x = 2; z = 3 }
   ;;
 end
 
@@ -9362,15 +9362,15 @@ module F6 = struct
 
   let f r =
     ignore (r : foo);
-    { r with x= 3; a= 4 }
+    { r with x = 3; a = 4 }
   ;;
 end
 
 module F7 = struct
   open M
 
-  let r = { x= 1; y= 2 }
-  let r : other = { x= 1; y= 2 }
+  let r = { x = 1; y = 2 }
+  let r : other = { x = 1; y = 2 }
 end
 
 module A = struct
@@ -9393,7 +9393,7 @@ module F8 = struct
     ; yyy : int
     }
 
-  let a : t = { x= 1; yyz= 2 }
+  let a : t = { x = 1; yyz = 2 }
 end
 
 (* PR#6004 *)
@@ -9422,7 +9422,7 @@ module Shadow1 = struct
 
   open M (* this open is unused, it isn't reported as shadowing 'x' *)
 
-  let y : t = { x= 0 }
+  let y : t = { x = 0 }
 end
 
 module Shadow2 = struct
@@ -9434,7 +9434,7 @@ module Shadow2 = struct
 
   open M (* this open shadows label 'x' *)
 
-  let y = { x= "" }
+  let y = { x = "" }
 end
 
 (* PR#6235 *)
@@ -9578,9 +9578,9 @@ let f = function
 ;;
 
 let g = function
-  | { l= x } -> ()
-  | ({ l1= x; l2= y }[@foo]) -> ()
-  | { l1= x; l2= y; _ } -> ()
+  | { l = x } -> ()
+  | ({ l1 = x; l2 = y }[@foo]) -> ()
+  | { l1 = x; l2 = y; _ } -> ()
 ;;
 
 let h ?l:(p = 1) ?y:u ?(x = 3) = 2
@@ -9691,7 +9691,7 @@ let tail3 = 0 :: ([] [@hello])
 let f ~l:(l[@foo]) = l
 let test x y = ( (+) [@foo] ) x y
 let test x = ( (~-) [@foo] )x
-let test contents = { contents= (contents [@foo]) }
+let test contents = { contents = (contents [@foo]) }
 
 class type t = object ((_[@foo])) end
 
@@ -9710,10 +9710,10 @@ let f = function
 
 ;;
 function
-| { contents= (contents[@foo]) } -> ()
+| { contents = (contents[@foo]) } -> ()
 
 ;;
-fun contents -> { contents= (contents [@foo]) }
+fun contents -> { contents = (contents [@foo]) }
 
 ;;
 ();

--- a/test/passing/record.ml
+++ b/test/passing/record.ml
@@ -49,7 +49,7 @@ let Mmmmmm.
     (* fooooooooo *) =
   ()
 
-let _ = {a; b: c= (match b with `A -> A | `B -> B | `C -> C); c}
+let _ = {a; b: c = (match b with `A -> A | `B -> B | `C -> C); c}
 
 let a () = A {A.a: t}
 
@@ -59,11 +59,11 @@ let x = {aaa: aa (* A *); bbb: bb}
 
 let x = {aaa: aa; (* A *) bbb: bb}
 
-let x = {(*test*) aaa: aa= aa; bbb: bb}
+let x = {(*test*) aaa: aa = aa; bbb: bb}
 
-let x = {aaa: aa (* A *)= aa; bbb: bb}
+let x = {aaa: aa (* A *) = aa; bbb: bb}
 
-let x = {aaa: aa= (* A *) aa; bbb: bb}
+let x = {aaa: aa = (* A *) aa; bbb: bb}
 
 let x = {aaa: aa; (* A *) bbb: bb}
 
@@ -79,11 +79,11 @@ let _ =
   (* comment here *)
   { (* comment here *)
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaa= aaaaaaaaaaaaaaaaaaaaaaaa
-  ; bbbbbbbbbbbb: bbbbbbbbbbb= bbbbbbbbbbbbbbbbb }
+  ; bbbbbbbbbbbb: bbbbbbbbbbb = bbbbbbbbbbbbbbbbb }
 
 let { (* comment here *)
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaa= aaaaaaaaaaaaaaaaaaaaaaaa
-    ; bbbbbbbbbbbb: bbbbbbbbbbb= bbbbbbbbbbbbbbbbb } =
+    ; bbbbbbbbbbbb: bbbbbbbbbbb = bbbbbbbbbbbbbbbbb } =
   e
 
 type t =
@@ -93,12 +93,12 @@ type t =
 
 let _ = x {a= (a': string); b= (b': string)}
 
-let _ = x {a: string= a'; b: string= b'}
+let _ = x {a: string = a'; b: string = b'}
 
-let _ = x {a= (a': string); b: string= b'}
+let _ = x {a= (a': string); b: string = b'}
 
-let _ = x {a: string= a'; b= (b': string)}
+let _ = x {a: string = a'; b= (b': string)}
 
 let x = function {a= (_: string); _} -> ()
 
-let x = function {a: string= _; _} -> ()
+let x = function {a: string = _; _} -> ()


### PR DESCRIPTION
This is a PR on your PR (https://github.com/ocaml-ppx/ocamlformat/pull/812)

I did not include your commit about `field-space` and added mine because I do not agree.

I factorized the formatting of record fields. I think this is a little improvement to the code.