### PR TITLE
Align tuples and constructors with arguments

### DIFF
--- a/src/Fmt_ast.ml
+++ b/src/Fmt_ast.ml
@@ -2669,7 +2669,7 @@ and fmt_class_type_field c ctx (cf : class_type_field) =
     $ fmt_atrs )
 
 and fmt_cases c ctx cs =
-  let case_len = function
+  let rec pattern_len ?(parens = 0) = function
     | Ppat_any -> Some 1
     | Ppat_var {txt= s; _}
      |Ppat_constant (Pconst_integer (s, _))
@@ -2679,19 +2679,27 @@ and fmt_cases c ctx cs =
     | Ppat_constant (Pconst_char _) -> Some 4 (* when the char is escaped *)
     | Ppat_variant (s, None) -> Some (String.length s + 1)
     | Ppat_constant (Pconst_string (s, _)) -> Some (String.length s + 2)
-    | Ppat_alias _ | Ppat_interval _ | Ppat_tuple _ | Ppat_construct _
+    | Ppat_tuple ps ->
+        (* commas and parenthesis *)
+        let init = ((List.length ps - 1) * 2) + parens in
+        fold_pattern_len ~parens:2 ~init ~f:( + ) ps
+    | Ppat_alias _ | Ppat_interval _ | Ppat_construct _
      |Ppat_variant (_, Some _)
      |Ppat_record _ | Ppat_array _ | Ppat_constraint _ | Ppat_type _
      |Ppat_or _ | Ppat_unpack _ | Ppat_lazy _ | Ppat_exception _
      |Ppat_extension _ | Ppat_open _ ->
         None
+  and fold_pattern_len ?parens ?(init = 0) ~f ps =
+    List.fold_until ~init ps
+      ~f:(fun acc pat ->
+        match pattern_len ?parens pat.ppat_desc with
+        | Some l -> Continue (f acc l)
+        | None -> Stop None)
+      ~finish:(fun acc -> Some acc)
   in
-  let max acc case =
-    match (acc, case_len case.pc_lhs.ppat_desc) with
-    | Some x, Some y -> Some (max x y)
-    | _ -> None
+  let max_len_name =
+    fold_pattern_len ~f:max (List.map ~f:(fun case -> case.pc_lhs) cs)
   in
-  let max_len_name = List.fold_left cs ~init:(Some 0) ~f:max in
   list_fl cs (fun ~first ~last {pc_lhs; pc_guard; pc_rhs} ->
       let xrhs = sub_exp ~ctx pc_rhs in
       let indent =
@@ -2732,7 +2740,7 @@ and fmt_cases c ctx cs =
         fmt_if_k
           ( c.conf.align_cases
           && not (Cmts.has_after c.cmts xlhs.ast.ppat_loc) )
-          ( match (max_len_name, case_len xlhs.ast.ppat_desc) with
+          ( match (max_len_name, pattern_len xlhs.ast.ppat_desc) with
           | Some max_len, Some len -> str (String.make (max_len - len) ' ')
           | _ -> noop )
       in

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -60,3 +60,21 @@ let fooooooooooo =
       (* foooooooooooooooooooooo foooooooooooooooo foooooooooooooo
          fooooooooo*)
   | _                   -> fooooooooooooooooooo
+
+let _ =
+  match (a, b) with
+  | A, B   -> a
+  | AA, BB -> b
+  | p      -> c
+
+let _ =
+  match (a, b) with
+  | A, B           -> a
+  | AA, BB         -> b
+  | longer_pattern -> c
+
+let _ =
+  match (a, b) with
+  | (A, B), B      -> a
+  | pat, BB        -> b
+  | longer_pattern -> c

--- a/test/passing/align_cases.ml
+++ b/test/passing/align_cases.ml
@@ -33,8 +33,8 @@ type x =
 let fooooooooooo =
   match foooooooooooooooooooooooo with
   | Bfooooooooooooooooo -> foooooooooooo
-  | C (a, b, c, d) -> fooooooooooooooooooo
-  | _ -> fooooooooooooooooooo
+  | C (a, b, c, d)      -> fooooooooooooooooooo
+  | _                   -> fooooooooooooooooooo
 
 let fooooooooooo =
   match foooooooooooooooooooooooo with
@@ -78,3 +78,13 @@ let _ =
   | (A, B), B      -> a
   | pat, BB        -> b
   | longer_pattern -> c
+
+let _ =
+  match f with
+  | Foo     -> toto
+  | Bar ijx -> bar ijx
+
+let _ =
+  match f with
+  | `Foo     -> toto
+  | `Bar ijx -> bar ijx

--- a/test/passing/align_cases.ml.opts
+++ b/test/passing/align_cases.ml.opts
@@ -1,1 +1,1 @@
---align-constructors-decl --align-variants-decl --align-cases
+--break-cases=all --align-constructors-decl --align-variants-decl --align-cases


### PR DESCRIPTION
Fix https://github.com/ocaml-ppx/ocamlformat/issues/360 on top of https://github.com/ocaml-ppx/ocamlformat/pull/883
I changed the code a bit to make it recursive.