### PR TITLE
Detect before parsing

### DIFF
--- a/lib/Docstring.ml
+++ b/lib/Docstring.ml
@@ -153,5 +153,3 @@ let normalize ~parse_docstrings ~normalize_code text =
     let parsed = Odoc_parser.parse_comment ~location ~text in
     let c = {normalize_code} in
     Format.asprintf "Docstring(%a)%!" (odoc_docs c) (Odoc_parser.ast parsed)
-
-let is_repl_block x = String.is_prefix (String.strip x) ~prefix:"# "

--- a/lib/Docstring.mli
+++ b/lib/Docstring.mli
@@ -32,12 +32,3 @@ val normalize :
   -> string
 
 val normalize_text : string -> string
-
-val is_repl_block : string -> bool
-(** [is_repl_block x] returns whether [x] is a list of REPL phrases and
-    outputs of the form:
-
-    {v
-      # let this is = some phrase;;
-      this is some output
-    v} *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4445,11 +4445,11 @@ let fmt_file (type a) ~ctx ~fmt_code ~debug (fragment : a Extended_ast.t)
 
 let fmt_code ~debug =
   let rec fmt_code conf s =
-    match Parse_with_comments.parse Parse.ast Structure conf ~source:s with
+    match Parse_with_comments.parse Parse.ast Use_file conf ~source:s with
     | {ast; comments; source; prefix= _} ->
-        let cmts = Cmts.init Structure ~debug source ast comments in
-        let ctx = Pld (PStr ast) in
-        Ok (fmt_file ~ctx ~debug Structure source cmts conf ast ~fmt_code)
+        let cmts = Cmts.init Use_file ~debug source ast comments in
+        let ctx = Top in
+        Ok (fmt_file ~ctx ~debug Use_file source cmts conf ast ~fmt_code)
     | exception _ ->
         if Docstring.is_repl_block s then
           match

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4443,26 +4443,19 @@ let fmt_file (type a) ~ctx ~fmt_code ~debug (fragment : a Extended_ast.t)
       fmt_expression c (sub_exp ~ctx:(Str (Ast_helper.Str.eval e)) e)
   | Repl_file, l -> fmt_repl_file c ctx l
 
+let fmt_parse_result conf ~debug ast_kind ast source comments ~fmt_code =
+  let cmts = Cmts.init ast_kind ~debug source ast comments in
+  let ctx = Top in
+  Ok (fmt_file ~ctx ~debug ast_kind source cmts conf ast ~fmt_code)
+
 let fmt_code ~debug =
   let rec fmt_code conf s =
-    match Parse_with_comments.parse Parse.ast Use_file conf ~source:s with
-    | {ast; comments; source; prefix= _} ->
-        let cmts = Cmts.init Use_file ~debug source ast comments in
-        let ctx = Top in
-        Ok (fmt_file ~ctx ~debug Use_file source cmts conf ast ~fmt_code)
-    | exception _ ->
-        if Docstring.is_repl_block s then
-          match
-            Parse_with_comments.parse Parse.ast Repl_file conf ~source:s
-          with
-          | {ast; comments; source; prefix= _} ->
-              let cmts = Cmts.init Repl_file ~debug source ast comments in
-              let ctx = Top in
-              Ok
-                (fmt_file ~ctx ~debug Repl_file source cmts conf ast
-                   ~fmt_code )
-          | exception _ -> Error ()
-        else Error ()
+    match Parse_with_comments.parse_toplevel conf ~source:s with
+    | Either.First {ast; comments; source; prefix= _} ->
+        fmt_parse_result conf ~debug Use_file ast source comments ~fmt_code
+    | Second {ast; comments; source; prefix= _} ->
+        fmt_parse_result conf ~debug Repl_file ast source comments ~fmt_code
+    | exception _ -> Error ()
   in
   fmt_code
 

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -44,31 +44,28 @@ let sort_attributes : attributes -> attributes =
 let docstring (c : Conf.t) =
   Docstring.normalize ~parse_docstrings:c.parse_docstrings
 
+let normalize_comments dedup fmt comments =
+  let comments = dedup comments in
+  List.sort comments ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
+      Migrate_ast.Location.compare a b )
+  |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
+
+let normalize_parse_result ast_kind ast comments =
+  Format.asprintf "AST,%a,COMMENTS,[%a]" (Pprintast.ast ast_kind) ast
+    (normalize_comments (dedup_cmts ast_kind ast))
+    comments
+
 let normalize_code conf (m : Ast_mapper.mapper) txt =
   match Parse_with_comments.parse Parse.ast Use_file conf ~source:txt with
   | {ast; comments; _} ->
-      let comments = dedup_cmts Use_file ast comments in
-      let print_comments fmt (l : Cmt.t list) =
-        List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
-            Migrate_ast.Location.compare a b )
-        |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
-      in
       let ast = List.map ~f:(m.toplevel_phrase m) ast in
-      Format.asprintf "AST,%a,COMMENTS,[%a]" (Pprintast.ast Use_file) ast
-        print_comments comments
+      normalize_parse_result Use_file ast comments
   | exception _
     when Docstring.is_repl_block txt && conf.parse_toplevel_phrases -> (
     match Parse_with_comments.parse Parse.ast Repl_file conf ~source:txt with
     | {ast; comments; _} ->
-        let comments = dedup_cmts Repl_file ast comments in
-        let print_comments fmt (l : Cmt.t list) =
-          List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
-              Migrate_ast.Location.compare a b )
-          |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
-        in
         let ast = List.map ~f:(m.repl_phrase m) ast in
-        Format.asprintf "AST,%a,COMMENTS,[%a]" (Pprintast.ast Repl_file) ast
-          print_comments comments
+        normalize_parse_result Repl_file ast comments
     | exception _ -> txt )
   | exception _ -> txt
 

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -45,16 +45,16 @@ let docstring (c : Conf.t) =
   Docstring.normalize ~parse_docstrings:c.parse_docstrings
 
 let normalize_code conf (m : Ast_mapper.mapper) txt =
-  match Parse_with_comments.parse Parse.ast Structure conf ~source:txt with
+  match Parse_with_comments.parse Parse.ast Use_file conf ~source:txt with
   | {ast; comments; _} ->
-      let comments = dedup_cmts Structure ast comments in
+      let comments = dedup_cmts Use_file ast comments in
       let print_comments fmt (l : Cmt.t list) =
         List.sort l ~compare:(fun {Cmt.loc= a; _} {Cmt.loc= b; _} ->
             Migrate_ast.Location.compare a b )
         |> List.iter ~f:(fun {Cmt.txt; _} -> Format.fprintf fmt "%s," txt)
       in
-      let ast = m.structure m ast in
-      Format.asprintf "AST,%a,COMMENTS,[%a]" Pprintast.structure ast
+      let ast = List.map ~f:(m.toplevel_phrase m) ast in
+      Format.asprintf "AST,%a,COMMENTS,[%a]" (Pprintast.ast Use_file) ast
         print_comments comments
   | exception _
     when Docstring.is_repl_block txt && conf.parse_toplevel_phrases -> (

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -56,17 +56,15 @@ let normalize_parse_result ast_kind ast comments =
     comments
 
 let normalize_code conf (m : Ast_mapper.mapper) txt =
-  match Parse_with_comments.parse Parse.ast Use_file conf ~source:txt with
-  | {ast; comments; _} ->
-      let ast = List.map ~f:(m.toplevel_phrase m) ast in
-      normalize_parse_result Use_file ast comments
-  | exception _
-    when Docstring.is_repl_block txt && conf.parse_toplevel_phrases -> (
-    match Parse_with_comments.parse Parse.ast Repl_file conf ~source:txt with
-    | {ast; comments; _} ->
-        let ast = List.map ~f:(m.repl_phrase m) ast in
-        normalize_parse_result Repl_file ast comments
-    | exception _ -> txt )
+  match Parse_with_comments.parse_toplevel conf ~source:txt with
+  | First {ast; comments; _} ->
+      normalize_parse_result Use_file
+        (List.map ~f:(m.toplevel_phrase m) ast)
+        comments
+  | Second {ast; comments; _} ->
+      normalize_parse_result Repl_file
+        (List.map ~f:(m.repl_phrase m) ast)
+        comments
   | exception _ -> txt
 
 let make_mapper conf ~ignore_doc_comments =

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -83,3 +83,18 @@ let parse ?(disable_w50 = false) parse fragment (conf : Conf.t) ~source =
         {ast; comments; prefix= hash_bang; source} )
   in
   match List.rev !w50 with [] -> t | w50 -> raise (Warning50 w50)
+
+(** [is_repl_block x] returns whether [x] is a list of REPL phrases and
+    outputs of the form:
+
+    {v
+    # let this is = some phrase;;
+    this is some output
+    v} *)
+let is_repl_block x = String.is_prefix (String.strip x) ~prefix:"# "
+
+let parse_toplevel ?disable_w50 conf ~source =
+  let open Extended_ast in
+  if is_repl_block source && conf.Conf.parse_toplevel_phrases then
+    Either.Second (parse ?disable_w50 Parse.ast Repl_file conf ~source)
+  else First (parse ?disable_w50 Parse.ast Use_file conf ~source)

--- a/lib/Parse_with_comments.mli
+++ b/lib/Parse_with_comments.mli
@@ -34,3 +34,13 @@ val parse :
   -> source:string
   -> 'a with_comments
 (** @raise [Warning50] on misplaced documentation comments. *)
+
+val parse_toplevel :
+     ?disable_w50:bool
+  -> Conf.t
+  -> source:string
+  -> ( Extended_ast.use_file with_comments
+     , Extended_ast.repl_file with_comments )
+     Either.t
+(** Variant of {!parse} that use {!Extended_ast.Parse.toplevel}. This
+    function handles [conf.parse_toplevel_phrases]. *)

--- a/test/passing/tests/doc_comments-no-wrap.mli.err
+++ b/test/passing/tests/doc_comments-no-wrap.mli.err
@@ -10,7 +10,7 @@ Warning: tests/doc_comments.mli:104 exceeds the margin
 Warning: tests/doc_comments.mli:298 exceeds the margin
 Warning: tests/doc_comments.mli:344 exceeds the margin
 Warning: tests/doc_comments.mli:351 exceeds the margin
-Warning: tests/doc_comments.mli:413 exceeds the margin
-Warning: tests/doc_comments.mli:422 exceeds the margin
-Warning: tests/doc_comments.mli:479 exceeds the margin
-Warning: tests/doc_comments.mli:509 exceeds the margin
+Warning: tests/doc_comments.mli:414 exceeds the margin
+Warning: tests/doc_comments.mli:423 exceeds the margin
+Warning: tests/doc_comments.mli:480 exceeds the margin
+Warning: tests/doc_comments.mli:510 exceeds the margin

--- a/test/passing/tests/doc_comments-no-wrap.mli.ref
+++ b/test/passing/tests/doc_comments-no-wrap.mli.ref
@@ -367,8 +367,9 @@ end
 (** {[
       #use "import.cinaps";;
 
-      List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
-      : unit -> %s = \"get_%s\"" name type_ name)
+      List.iter all_fields ~f:(fun (name, type_) ->
+          printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_
+            name )
     ]} *)
 
 (** {[

--- a/test/passing/tests/doc_comments.mli.err
+++ b/test/passing/tests/doc_comments.mli.err
@@ -10,7 +10,7 @@ Warning: tests/doc_comments.mli:104 exceeds the margin
 Warning: tests/doc_comments.mli:298 exceeds the margin
 Warning: tests/doc_comments.mli:344 exceeds the margin
 Warning: tests/doc_comments.mli:351 exceeds the margin
-Warning: tests/doc_comments.mli:413 exceeds the margin
-Warning: tests/doc_comments.mli:422 exceeds the margin
-Warning: tests/doc_comments.mli:479 exceeds the margin
-Warning: tests/doc_comments.mli:509 exceeds the margin
+Warning: tests/doc_comments.mli:414 exceeds the margin
+Warning: tests/doc_comments.mli:423 exceeds the margin
+Warning: tests/doc_comments.mli:480 exceeds the margin
+Warning: tests/doc_comments.mli:510 exceeds the margin

--- a/test/passing/tests/doc_comments.mli.ref
+++ b/test/passing/tests/doc_comments.mli.ref
@@ -367,8 +367,9 @@ end
 (** {[
       #use "import.cinaps";;
 
-      List.iter all_fields ~f:(fun (name, type_) -> printf "\nexternal get_%s
-      : unit -> %s = \"get_%s\"" name type_ name)
+      List.iter all_fields ~f:(fun (name, type_) ->
+          printf "\nexternal get_%s\n: unit -> %s = \"get_%s\"" name type_
+            name )
     ]} *)
 
 (** {[


### PR DESCRIPTION
The goal is to avoid attempting parsing in a language and then trying an other. The function to detect whether a block is a repl exists and I think the rule shouldn't be more complicated than that (the users will have to guess the rule).

Change code blocks to be parsed as `Use_file` instead of `Structure`, just like `.ml` files are parsed as `Use_file`.
The second commit factorize the normalizing code, which is otherwise a lot of duplication.