### PR TITLE
Safer printing of ;; after repl phrase

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -734,6 +734,7 @@ module T = struct
     | Ctf of class_type_field
     | Tli of toplevel_item
     | Top
+    | Rep
 
   let dump fs = function
     | Pld l -> Format.fprintf fs "Pld:@\n%a" Pprintast.payload l
@@ -755,6 +756,7 @@ module T = struct
     | Tli (`Directive d) ->
         Format.fprintf fs "Dir:@\n%a" Pprintast.toplevel_phrase (Ptop_dir d)
     | Top -> Format.pp_print_string fs "Top"
+    | Rep -> Format.pp_print_string fs "Rep"
 end
 
 include T
@@ -778,6 +780,7 @@ let attributes = function
   | Ctf x -> x.pctf_attributes
   | Top -> []
   | Tli _ -> []
+  | Rep -> []
 
 let location = function
   | Pld _ -> Location.none
@@ -797,6 +800,7 @@ let location = function
   | Tli (`Item x) -> x.pstr_loc
   | Tli (`Directive x) -> x.pdir_loc
   | Top -> Location.none
+  | Rep -> Location.none
 
 let break_between_modules s cc (i1, c1) (i2, c2) =
   let has_doc itm = List.exists ~f:Attr.is_doc (attributes itm) in
@@ -1143,7 +1147,7 @@ end = struct
       | _ -> assert false )
     | Clf _ -> assert false
     | Ctf _ -> assert false
-    | Top | Tli _ -> assert false
+    | Top | Tli _ | Rep -> assert false
 
   let assert_check_typ xtyp =
     let dump {ctx; ast= typ} = dump ctx (Typ typ) in
@@ -1220,6 +1224,7 @@ end = struct
     | Ctf _ -> assert false
     | Mty _ -> assert false
     | Mod _ -> assert false
+    | Rep -> assert false
 
   let assert_check_cty xcty =
     let dump {ctx; ast= cty} = dump ctx (Cty cty) in
@@ -1278,6 +1283,7 @@ end = struct
     | Ctf _ -> assert false
     | Mty _ -> assert false
     | Mod _ -> assert false
+    | Rep -> assert false
 
   let assert_check_cl xcl =
     let dump {ctx; ast= cl} = dump ctx (Cl cl) in
@@ -1388,7 +1394,7 @@ end = struct
       | _ -> assert false )
     | Clf x -> assert (check_pcstr_fields [x])
     | Ctf _ -> assert false
-    | Top | Tli _ -> assert false
+    | Top | Tli _ | Rep -> assert false
 
   let assert_check_pat xpat =
     let dump {ctx; ast= pat} = dump ctx (Pat pat) in
@@ -1556,7 +1562,7 @@ end = struct
     | Cty _ -> assert false
     | Ctf _ -> assert false
     | Clf x -> assert (check_pcstr_fields [x])
-    | Mod _ | Top | Tli _ | Typ _ | Pat _ | Mty _ | Sig _ | Td _ ->
+    | Mod _ | Top | Tli _ | Typ _ | Pat _ | Mty _ | Sig _ | Td _ | Rep ->
         assert false
 
   let assert_check_exp xexp =
@@ -1735,7 +1741,7 @@ end = struct
     | { ctx= Exp _
       ; ast=
           ( Pld _ | Top | Tli _ | Pat _ | Cl _ | Mty _ | Mod _ | Sig _
-          | Str _ | Clf _ | Ctf _ ) }
+          | Str _ | Clf _ | Ctf _ | Rep ) }
      |{ctx= Vb _; ast= _}
      |{ctx= _; ast= Vb _}
      |{ctx= Td _; ast= _}
@@ -1743,13 +1749,13 @@ end = struct
      |{ ctx= Cl _
       ; ast=
           ( Pld _ | Top | Tli _ | Pat _ | Mty _ | Mod _ | Sig _ | Str _
-          | Clf _ | Ctf _ ) }
+          | Clf _ | Ctf _ | Rep ) }
      |{ ctx=
           ( Pld _ | Top | Tli _ | Typ _ | Cty _ | Pat _ | Mty _ | Mod _
-          | Sig _ | Str _ | Clf _ | Ctf _ )
+          | Sig _ | Str _ | Clf _ | Ctf _ | Rep )
       ; ast=
           ( Pld _ | Top | Tli _ | Pat _ | Exp _ | Cl _ | Mty _ | Mod _
-          | Sig _ | Str _ | Clf _ | Ctf _ ) } ->
+          | Sig _ | Str _ | Clf _ | Ctf _ | Rep ) } ->
         None
 
   (** [prec_ast ast] is the precedence of [ast]. Meaningful for binary
@@ -1831,7 +1837,8 @@ end = struct
       | Pcl_apply _ -> Some Apply
       | Pcl_structure _ -> Some Apply
       | _ -> None )
-    | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _ | Tli _ | Clf _ | Ctf _ ->
+    | Top | Pat _ | Mty _ | Mod _ | Sig _ | Str _ | Tli _ | Clf _ | Ctf _
+     |Rep ->
         None
 
   (** [ambig_prec {ctx; ast}] holds when [ast] is ambiguous in its context

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -185,6 +185,7 @@ type t =
   | Ctf of class_type_field
   | Tli of toplevel_item
   | Top
+  | Rep  (** Repl phrase *)
 
 val is_top : t -> bool
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -194,7 +194,11 @@ let update_items_config c items update_config =
   let _, items = List.fold_map items ~init:c ~f:with_config in
   items
 
-let box_semisemi b k = hvbox_if b 0 (k $ fmt_if b "@,;;")
+let box_semisemi ~parent_ctx b k =
+  match parent_ctx with
+  | _ when not b -> k
+  | Rep -> k $ fmt ";;"
+  | _ -> hvbox 0 (k $ fmt "@,;;")
 
 let fmt_hole () = str "_"
 
@@ -4192,7 +4196,8 @@ and fmt_type c ?ext ?eq rec_flag decls ctx =
   let ast x = Td x in
   fmt_item_list c ctx update_config ast fmt_decl decls
 
-and fmt_structure_item c ~last:last_item ?ext ~semisemi {ctx= _; ast= si} =
+and fmt_structure_item c ~last:last_item ?ext ~semisemi
+    {ctx= parent_ctx; ast= si} =
   protect c (Str si)
   @@
   let ctx = Str si in
@@ -4200,7 +4205,8 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi {ctx= _; ast= si} =
   let fmt_cmts_after = Cmts.Toplevel.fmt_after c si.pstr_loc in
   (fun k ->
     fmt_cmts_before
-    $ hvbox 0 ~name:"stri" (box_semisemi semisemi (k $ fmt_cmts_after)) )
+    $ hvbox 0 ~name:"stri"
+        (box_semisemi ~parent_ctx semisemi (k $ fmt_cmts_after)) )
   @@
   match si.pstr_desc with
   | Pstr_attribute attr -> fmt_floating_attributes_and_docstrings c [attr]
@@ -4438,30 +4444,29 @@ let fmt_toplevel_directive c ~semisemi dir =
         $ fmt_dir_arg pdira_desc
         $ Cmts.fmt_after c pdira_loc
   in
-  Cmts.fmt c pdir_loc (box_semisemi semisemi (name $ args))
+  Cmts.fmt c pdir_loc (box_semisemi ~parent_ctx:Top semisemi (name $ args))
 
 let flatten_ptop =
   List.concat_map ~f:(function
     | Ptop_def items -> List.map items ~f:(fun i -> `Item i)
     | Ptop_dir d -> [`Directive d] )
 
-let fmt_toplevel c ctx itms =
+let fmt_toplevel ?(force_semisemi = false) c ctx itms =
   let itms = flatten_ptop itms in
   let update_config c = function
     | `Item {pstr_desc= Pstr_attribute atr; _} -> update_config c [atr]
     | _ -> c
   in
   let fmt_item c ctx ~prev:_ ~next itm =
+    let last = Option.is_none next in
     let semisemi =
       match (itm, next) with
       | _, Some (`Item {pstr_desc= Pstr_eval _; _}, _) -> true
       | `Item _, Some (`Directive _, _) -> true
-      | _ -> false
+      | _ -> force_semisemi && last
     in
     match itm with
-    | `Item i ->
-        fmt_structure_item c ~last:(Option.is_none next) ~semisemi
-          (sub_str ~ctx i)
+    | `Item i -> fmt_structure_item c ~last ~semisemi (sub_str ~ctx i)
     | `Directive d -> fmt_toplevel_directive c ~semisemi d
   in
   let ast x = Tli x in
@@ -4469,14 +4474,13 @@ let fmt_toplevel c ctx itms =
 
 let fmt_repl_phrase c ctx {prepl_phrase; prepl_output} =
   str "# "
-  $ fmt_toplevel c ctx [prepl_phrase]
-  $ fmt ";;"
+  $ fmt_toplevel ~force_semisemi:true c ctx [prepl_phrase]
   $ fmt_if_k
       (not (String.is_empty prepl_output))
       (break 1000 0 $ str prepl_output)
 
-let fmt_repl_file c ctx itms =
-  vbox 0 @@ list itms "@;<1000 0>" @@ fmt_repl_phrase c ctx
+let fmt_repl_file c _ itms =
+  vbox 0 @@ list itms "@;<1000 0>" @@ fmt_repl_phrase c Rep
 
 (** Entry points *)
 


### PR DESCRIPTION
Use the existing logic for printing `;;`. Add a context type for repl blocks and use it to detect how the `;;` should be formatted. (same line or box+break)

What do you think about this approach ?